### PR TITLE
#51 feat: confirmModal 공통 컴포넌트 생성

### DIFF
--- a/src/components/common/button/constants.ts
+++ b/src/components/common/button/constants.ts
@@ -10,7 +10,7 @@ export const btnColorMap = {
   green: 'bg-green-default text-white hover:bg-green-hover',
   red: 'bg-red-default text-white hover:bg-red-hover',
   dark: 'bg-main-header text-white',
-  outline: 'border border-black text-black',
+  outline: 'border border-black text-black hover:bg-gray-100',
 } as const;
 
 export const iconMap = {

--- a/src/components/common/modal/ConfirmModal.tsx
+++ b/src/components/common/modal/ConfirmModal.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Button from '@/components/common/button/Button';
+import CommonInput from '@/components/common/input/Input';
+
+type ConfirmProps = {
+  title?: string;
+  content?: string;
+  input?: boolean;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  className?: string;
+};
+
+const ConfirmModal = ({
+  title = '모임을 나가시겠습니까?',
+  content,
+  input = false,
+  confirmText = '확인',
+  cancelText = '취소',
+  onConfirm,
+  onCancel,
+  className,
+}: ConfirmProps) => {
+  return (
+    <div
+      className={`w-[320px] rounded-xl border border-main-medium bg-white p-4 ${className}`}
+    >
+      <p className="mb-1 text-center text-lg">{title}</p>
+      {content && (
+        <p className="text-center text-sm text-gray-400">{content}</p>
+      )}
+      {input && <CommonInput box="textarea" />}
+      <div className="mt-3 flex w-full justify-center gap-2">
+        <Button color="outline" onClick={onCancel}>
+          {cancelText}
+        </Button>
+        <Button onClick={onConfirm}>{confirmText}</Button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;


### PR DESCRIPTION
## 🔗 관련 이슈

#51

## ✨ 작업 목록

- [x] 컨펌 모달 공통 컴포넌트 생성

## ✅ 체크리스트

- [x] 코드가 정상적으로 작동하고 테스트를 통과했나요?
- [x] 스타일 가이드를 따랐나요?
- [x] PR 제목과 커밋 메시지를 명확하게 작성했나요?
- [x] 관련 이슈를 연결했나요? (예: `close #1`)

## 🙋‍♀️ 기타 참고사항(선택)

### ✅ 사용 예시

```tsx
<ConfirmModal title="작성된 글을 삭제하시겠습니까?" />
<ConfirmModal input={true} content="탈퇴 사유를 작성해주세요" />
```
<img width="328" alt="스크린샷 2025-05-03 오전 8 17 28" src="https://github.com/user-attachments/assets/70106303-9e9c-4f0f-a4c5-c87394ff5b39" />
￼

### ✅ Props 타입 정의

```ts
type ConfirmProps = {
  title?: string; //컨펌 모달 제목
  content?: string; //컨펌 모달 소제목
  input?: boolean; //input창 유무(탈퇴 사유 수집용)
  confirmText?: string; //확인 메시지
  cancelText?: string; //취소 메시지
  onConfirm?: () => void;
  onCancel?: () => void;
  className?: string;
};

```