### PR TITLE
#9 fix: Input / Dropdown className optional 설정과 드롭메뉴 Close 기능 수정

### DIFF
--- a/src/components/common/input/Dropdown.tsx
+++ b/src/components/common/input/Dropdown.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type DropdownProps = {
   selected: string;
   onSelect: (value: string) => void;
-  placeholder: string; // string 타입으로 제한
+  placeholder?: string; // string 타입으로 제한
   className?: string;
   categories: string[];
+  align?: 'left' | 'center';
 };
 
 export default function Dropdown({
@@ -16,16 +17,33 @@ export default function Dropdown({
   placeholder,
   className = '',
   categories,
+  align,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
 
+  const dropMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleOutsideClose = (e: { target: any }) => {
+      // useRef current에 담긴 엘리먼트 바깥(외부)을 클릭 시 드롭다운 메뉴 닫힘
+      if (isOpen && !dropMenuRef.current?.contains(e.target)) setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handleOutsideClose);
+
+    return () => document.removeEventListener('click', handleOutsideClose);
+  }, [isOpen]);
+
   return (
-    <div className={`relative w-full ${className}`}>
+    <div className={`relative w-full ${className}`} ref={dropMenuRef}>
       <div
         className="flex cursor-pointer items-center justify-between gap-[20px] border-b-[1px] border-main-base py-2"
-        onClick={() => setIsOpen(prev => !prev)}
+        onClick={() => setIsOpen(!isOpen)}
       >
-        <span className="font-gmarket text-[15px] font-light text-gray-400">
+        <span
+          className={`w-full font-gmarket text-[15px] font-light text-gray-400 ${
+            align === 'center' ? 'text-center' : 'text-left'
+          }`}
+        >
           {selected || placeholder || '선택하세요.'}
         </span>
         <span className="text-xl text-main-base">▼</span>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -7,7 +7,7 @@ interface BaseProps {
   placeholder?: string;
   box?: InputType;
   value?: string;
-  className: string;
+  className?: string;
   onChange?: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void;
@@ -34,12 +34,12 @@ const CommonInput: React.FC<InputProps> = ({
   ...props
 }) => {
   return (
-    <div className={`flex flex-col space-y-2 text-gray-800 ${className}`}>
+    <div className="flex flex-col space-y-2 text-gray-800">
       {label && <label className="font-semibold">{label}</label>}
 
       {box === 'textarea' ? (
         <textarea
-          className="min-h-[120px] w-full resize-none rounded-xl border border-main-base bg-transparent p-3 text-[15px] shadow-sm transition focus:outline-none"
+          className={`min-h-[120px] w-full resize-none rounded-xl border border-main-base p-3 text-[15px] shadow-sm transition focus:outline-none ${className}`}
           placeholder={placeholder}
           value={value}
           onChange={onChange}
@@ -49,8 +49,8 @@ const CommonInput: React.FC<InputProps> = ({
         <input
           className={`w-full ${
             box === 'box'
-              ? 'rounded-xl border border-main-base bg-transparent p-3 text-[15px] shadow-sm transition focus:outline-none'
-              : 'border-b border-main-base bg-transparent text-[15px] transition-all focus:outline-none'
+              ? ` ${className} rounded-xl border border-main-base p-3 text-[15px] shadow-sm transition focus:outline-none`
+              : `border-b border-main-base bg-transparent text-[15px] transition-all focus:outline-none ${className}`
           }`}
           type="text"
           placeholder={placeholder}


### PR DESCRIPTION
## 🔗 관련 이슈

#9 

## ✨ 작업 목록

- [x] Input 컴포넌트 className optional 설정
- [x] Dropdown 컴포넌트 외부 클릭 시 드롭메뉴 닫기

## ✅ 체크리스트

- [x] 코드가 정상적으로 작동하고 테스트를 통과했나요?
- [x] 스타일 가이드를 따랐나요?
- [x] PR 제목과 커밋 메시지를 명확하게 작성했나요?
- [x] 관련 이슈를 연결했나요? (예: `close #1`)

## 🙋‍♀️ 기타 참고사항(선택)

```tsx
// ▪️ Dropdown

<Dropdown
        selected={selectedCategory}
        onSelect={setSelectedCategory}
        placeholder="카테고리를 선택하세요"
        categories={CATEGORY_LIST}
        align="center"
        className="mt-4"
      />

// ▪️ CommonInput

<CommonInput
        label="제목"
        box="line"
        placeholder="제목을 입력하세요"
        value={text}
        onChange={(e) => setText(e.target.value)}
        className="bg-transparent"
      />

 <CommonInput
        label="내용"
        box="textarea"
        placeholder="내용을 입력하세요"
        value={text}
        onChange={(e) => setText(e.target.value)}
        className="min-h-[200px]"
      />
```
▪️ Dropdown
- `align` : placeholder 텍스트 정렬 방법 ( left 가 default )
- `className` : 추가 css 코드 작성 ( optional )

▪️ CommonInput
- `className` : 추가 css 코드 작성 ( optional ) [ ex. Input 배경색 ( default : white ) 제거 : bg-transparent / textarea 높이 설정 : min-h-[200px] ]

