### PR TITLE
#132 fix: 멤버 카드 마진 수정 및 로딩 화면 수정

### DIFF
--- a/src/components/moim/moimmember/index.tsx
+++ b/src/components/moim/moimmember/index.tsx
@@ -15,6 +15,7 @@ import { useMutation } from '@tanstack/react-query';
 import { chatOption } from '@/api/options/chatOption';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/useAuthStore';
+import Loading from '@/app/loading';
 
 type User = {
   id: number;
@@ -38,16 +39,18 @@ export default function MoimMemberCard({ params }: Props) {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const { isLoggedIn } = useAuthStore();
+  const { access, hydrated, isLoggedIn, fetchUser } = useAuthStore();
 
   const userId = Number(params.userId);
 
   const postJoinMutation = useMutation(chatOption.joinChat());
 
   useEffect(() => {
+    if (!hydrated) return;
+
     if (!isLoggedIn) {
       alert('로그인이 필요합니다.');
-      router.replace('/login');
+      router.replace('/auth/login');
       return;
     }
 
@@ -67,14 +70,16 @@ export default function MoimMemberCard({ params }: Props) {
     };
 
     fetchUserProfile();
-  }, [userId]);
+  }, [hydrated, isLoggedIn, userId, router]);
+
+  if (loading) return <Loading />;
 
   if (!user) return <div> 프로필 정보를 표시할 수 없습니다. </div>;
 
   const fullImageUrl = user?.profile_image || Logo;
 
   return (
-    <div className="mx-auto w-full max-w-screen-md px-4">
+    <div className="mx-auto my-[3%] w-full max-w-screen-md px-4">
       <MyMoimBox title={`${user?.nickname} 님의 정보`}>
         <div className="mx-auto flex flex-col items-center justify-center gap-[10px] text-center">
           <div className="relative h-[150px] w-[150px]">


### PR DESCRIPTION
## 🔗 관련 이슈

#132 

## ✨ 작업 목록

- [ ] 멤버 카드 마진 수정
- [ ] 로딩 화면 수정

## ✅ 체크리스트

- [ ] 코드가 정상적으로 작동하고 테스트를 통과했나요?
- [ ] 스타일 가이드를 따랐나요?
- [ ] PR 제목과 커밋 메시지를 명확하게 작성했나요?
- [ ] 관련 이슈를 연결했나요? (예: `close #1`)

