### PR TITLE
#156 refactor: 메시지 배열 생성하는 대신 tanstack query 캐시 업데이트 하는 방식으로 변경

### DIFF
--- a/src/components/chats/ChatMessages.tsx
+++ b/src/components/chats/ChatMessages.tsx
@@ -6,7 +6,7 @@ import { useChatStore } from '@/store/useChatStore';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { chatOption } from '@/api/options/chatOption';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSocket } from '@/hooks/useSocket';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
@@ -19,26 +19,32 @@ const ChatMessages = ({ room_id }: MsgsProps) => {
   const currentUserId = useAuthStore(state => state.user?.id!);
 
   const { selectedRoomTitle, exitRoom } = useChatStore();
-  const inputRef = useRef<HTMLInputElement>(null);
 
+  const inputRef = useRef<HTMLInputElement>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
-  const { newMessage, sendMessage } = useSocket(room_id, access);
-  const { data: oldMessages = [] } = useQuery(chatOption.chatMessages(room_id));
-  const allMessages = [...oldMessages, ...newMessage];
+  const { data: allMessages = [] } = useQuery(chatOption.chatMessages(room_id));
+  const { sendMessage } = useSocket(room_id, access);
 
-  const { otherId, otherImage } = useMemo(() => {
+  const [otherUserId, setOtherUserId] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    setOtherUserId(undefined);
+  }, [room_id]);
+
+  useEffect(() => {
+    if (otherUserId) return;
+
     const otherMsg = allMessages.find(
       msg => msg.chat_user_id !== currentUserId,
     );
+    if (otherMsg) {
+      setOtherUserId(otherMsg.chat_user_id);
+    }
+  }, [allMessages, currentUserId, otherUserId]);
 
-    return {
-      otherId: otherMsg?.chat_user_id,
-      otherImage: otherMsg?.profile_image,
-    };
-  }, [allMessages, currentUserId]);
-  const { data: otherProfile } = useQuery(chatOption.chatUser(otherId));
-  const userProfileImage = otherProfile?.profile_image || otherImage || null;
+  const { data: otherProfile } = useQuery(chatOption.chatUser(otherUserId));
+  const userProfileImage = otherProfile?.profile_image || null;
 
   const handleSend = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,14 +1,12 @@
+import { chatOption } from '@/api/options/chatOption';
 import { Chats } from '@/types/chat';
-import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
 
 export const useSocket = (room_id: string, access: string | null) => {
   const socketRef = useRef<WebSocket | null>(null);
 
-  const [newMessage, setNewMessage] = useState<Chats[]>([]);
-
-  useEffect(() => {
-    setNewMessage([]);
-  }, [room_id]);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!room_id || !access) return;
@@ -20,7 +18,14 @@ export const useSocket = (room_id: string, access: string | null) => {
     socket.onmessage = event => {
       try {
         const parsed = JSON.parse(event.data);
-        setNewMessage(prev => [...prev, parsed]);
+
+        queryClient.setQueryData<Chats[]>(
+          chatOption.chatMessages(room_id).queryKey,
+          old => {
+            if (!old) return [parsed];
+            return [...old, parsed];
+          },
+        );
       } catch (e) {
         console.error('메시지 파싱 실패:', e);
       }
@@ -29,7 +34,7 @@ export const useSocket = (room_id: string, access: string | null) => {
     return () => {
       socket.close();
     };
-  }, [room_id, access]);
+  }, [room_id, access, queryClient]);
 
   const sendMessage = (message: string) => {
     if (socketRef.current?.readyState === WebSocket.OPEN && message.trim()) {
@@ -43,7 +48,6 @@ export const useSocket = (room_id: string, access: string | null) => {
   };
 
   return {
-    newMessage,
     sendMessage,
   };
 };


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #156 

## ✨ 작업 목록

- [x] useSocket 커스텀 훅에 캐시 업데이트 로직 추가
- [x] 채팅창 컴포넌트에 캐시 업데이트 로직 반영

## ✅ 체크리스트

- [x] 코드가 정상적으로 작동하고 테스트를 통과했나요?
- [x] 스타일 가이드를 따랐나요?
- [x] PR 제목과 커밋 메시지를 명확하게 작성했나요?
- [x] 관련 이슈를 연결했나요? (예: `close #1`)

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
